### PR TITLE
Fix bug in HashMap count()

### DIFF
--- a/HashMap
+++ b/HashMap
@@ -60,7 +60,7 @@ struct HashMap {
     bool count(const K& k) const {
         const Node &node = find(k);
 
-        return nodes.state == State::used;
+        return node.state == State::used;
     }
 };
 


### PR DESCRIPTION
## Summary
- fix `HashMap::count` to reference the found node

## Testing
- `g++ -std=c++17 -Wall -Wextra -pedantic -O2 -x c++ HashMap -o HashMap_test` *(fails: invalid types in main function)*

------
https://chatgpt.com/codex/tasks/task_b_685fb6805e60832783a8380a73b72c50