### PR TITLE
Fix spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-Useful code snippets for programing contests (e.g. Codeforces, TopCoder, etc)
+Useful code snippets for programming contests (e.g. Codeforces, TopCoder, etc)
 =====


### PR DESCRIPTION
## Summary
- update README typo: `programing` -> `programming`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685fb7ac3eb0832799afa7def1d329b8