### PR TITLE
Fix narrowing by using unsigned long long constants

### DIFF
--- a/hash_map.cpp
+++ b/hash_map.cpp
@@ -9,7 +9,9 @@
 
 using namespace std;
 
-template<class K, class V, int D = 20, K to_xor = 10778448979374848739ull, K to_mul = 14774228369217122871ull>
+template<class K, class V, int D = 20,
+         unsigned long long to_xor = 10778448979374848739ull,
+         unsigned long long to_mul = 14774228369217122871ull>
 struct HashMap {
     enum State {
         free,


### PR DESCRIPTION
## Summary
- avoid narrowing in `HashMap` by using `unsigned long long` default parameters

## Testing
- `g++ -std=c++17 hash_map.cpp -o hash_map.out`

------
https://chatgpt.com/codex/tasks/task_b_685fc73560bc8327bc225401913ee182