### PR TITLE
Ensure headers compile standalone

### DIFF
--- a/bitset.hpp
+++ b/bitset.hpp
@@ -1,3 +1,8 @@
+#include <bits/stdc++.h>
+
+using ull = unsigned long long;
+using namespace std;
+
 struct Bitset
 {
     ull * data;

--- a/dynamic_convex_hull_trick.hpp
+++ b/dynamic_convex_hull_trick.hpp
@@ -1,3 +1,7 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+using ll = long long;
 const ll is_query = -(1LL<<62);
 struct Line {
     ll m, b;

--- a/fenwick.hpp
+++ b/fenwick.hpp
@@ -1,3 +1,9 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+using ll = long long;
+using ull = unsigned long long;
+
 // Lightweight Fenwick Tree (Binary Indexed Tree)
 // Supports point updates and prefix sum queries.
 template <class T>

--- a/sqrt_sum_query.hpp
+++ b/sqrt_sum_query.hpp
@@ -1,3 +1,9 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+using ll = long long;
+using ull = unsigned long long;
+
 template <int K>
 struct add_sum {
     vector <long long> block_pref_sum;


### PR DESCRIPTION
## Summary
- include `<bits/stdc++.h>` in commonly used snippets
- add `using namespace std` and helper aliases for `ll` and `ull`

## Testing
- `bash test/run_tests.sh`
- `g++ -std=c++17 -fsyntax-only dynamic_convex_hull_trick.hpp && echo OK`
- `g++ -std=c++17 -fsyntax-only bitset.hpp && echo OK`
- `g++ -std=c++17 -fsyntax-only fenwick.hpp && echo OK`
- `g++ -std=c++17 -fsyntax-only sqrt_sum_query.hpp && echo OK`


------
https://chatgpt.com/codex/tasks/task_b_685fc736b1588327b9046e940b84084c