### PR TITLE
Add missing standard headers for compilation

### DIFF
--- a/2sat.hpp
+++ b/2sat.hpp
@@ -1,3 +1,4 @@
+#include <bits/stdc++.h>
 
 // 2-SAT solver based on Kosaraju's SCC algorithm
 // Variables are indexed from 0..n-1. For each variable x we use

--- a/berlekamp_massey.hpp
+++ b/berlekamp_massey.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 struct BerlekampMassey {
     int L, m, b, n;
     int mod;

--- a/binomial_prime_power.hpp
+++ b/binomial_prime_power.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 constexpr long long get_power(long long p, int e) {
     long long res = 1;
     for (int i = 0; i < e; i++) {

--- a/centroid_decomposition.hpp
+++ b/centroid_decomposition.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 struct graph {
     vector <vector <int> > g;
     vector <int> size;

--- a/compile_time_primes.hpp
+++ b/compile_time_primes.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 template<size_t a, size_t b>
 struct Min {
     const static size_t value = a < b ? a : b;

--- a/convex_hull.hpp
+++ b/convex_hull.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 struct Point {
     long long x, y;
     Point(long long xx = 0, long long yy = 0) : x(xx), y(yy) {}

--- a/convex_hull_dbl.hpp
+++ b/convex_hull_dbl.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 const long double eps = 1e-9;
 
 struct Point {

--- a/modular_class.cpp
+++ b/modular_class.cpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 template<long long modulo>
 struct Number {
     long long value;

--- a/prime_count.hpp
+++ b/prime_count.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 const int N = 1000000;
 
 int lp[N + 1];

--- a/queue_min.hpp
+++ b/queue_min.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 struct queueMin {
 
     queueMin() {}

--- a/segment_tree_interval_modification.hpp
+++ b/segment_tree_interval_modification.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 struct segmentTree {
 
     inline int modifyOperation(int x, int y) {

--- a/sqrt_sum_query.hpp
+++ b/sqrt_sum_query.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 template <int K>
 struct add_sum {
     vector <long long> block_pref_sum;

--- a/subset_convolution.hpp
+++ b/subset_convolution.hpp
@@ -2,6 +2,8 @@
 // Created by Evgeny Savinov on 08/09/16.
 //
 
+#include <bits/stdc++.h>
+
 using namespace std;
 
 

--- a/two_chinese.hpp
+++ b/two_chinese.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 #define forn(i, n) for (int i = 0; i < (n); ++i)
 #define ford(i, n) for (int i = (n) - 1; i >= 0; --i)
 #define pii pair <int, int>


### PR DESCRIPTION
## Summary
- include `<bits/stdc++.h>` in header-only modules to provide standard containers and utilities
- ensure examples with `ostream`, `vector`, and `assert` compile

## Testing
- `bash test/run_tests.sh`
- `g++ -std=c++17 /tmp/test_convex.cpp -I . -o /tmp/test_convex && echo "convex compiled"`
- `g++ -std=c++17 /tmp/test_modular.cpp -I . -o /tmp/test_modular && echo "modular compiled"`
- `/tmp/test_convex && /tmp/test_modular > /tmp/run_output.txt && cat /tmp/run_output.txt`


------
https://chatgpt.com/codex/tasks/task_b_685fc734353083278ff923ee3113145c