### PR TITLE
Fix duplicated default template arguments in nxt()

### DIFF
--- a/_2sat.cpp
+++ b/_2sat.cpp
@@ -407,7 +407,7 @@ inline void input(T &a) {
     if (neg) a = -a;
 }
 
-template<typename T = long long>
+template<typename T>
 inline T nxt() {
     T res;
     input(res);

--- a/dynamic_connectivity_memory_optimized.cpp
+++ b/dynamic_connectivity_memory_optimized.cpp
@@ -381,7 +381,7 @@ inline void input(T &a) {
     if (neg) a = -a;
 }
 
-template<typename T = long long>
+template<typename T>
 inline T nxt() {
     T res;
     input(res);

--- a/hopcroft_karp.cpp
+++ b/hopcroft_karp.cpp
@@ -408,7 +408,7 @@ inline void input(T &a) {
     if (neg) a = -a;
 }
 
-template<typename T = long long>
+template<typename T>
 inline T nxt() {
     T res;
     input(res);

--- a/suffix_array_tree.cpp
+++ b/suffix_array_tree.cpp
@@ -492,7 +492,7 @@ inline void input(T &a) {
     if (neg) a = -a;
 }
 
-template<typename T = long long>
+template<typename T>
 inline T nxt() {
     T res;
     input(res);

--- a/suffixtree_sa.cpp
+++ b/suffixtree_sa.cpp
@@ -476,7 +476,7 @@ inline void input(T &a) {
     if (neg) a = -a;
 }
 
-template<typename T = long long>
+template<typename T>
 inline T nxt() {
     T res;
     input(res);


### PR DESCRIPTION
## Summary
- remove redundant default argument from `nxt()` definitions in various files

## Testing
- `bash test/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_b_685fc7329f80832792c1f9ce0742e84f