### PR TITLE
Add stdc++ includes to header snippets

### DIFF
--- a/add_min_segment_tree.hpp
+++ b/add_min_segment_tree.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 struct Data {
     int val;
     int pos;

--- a/bin_search.hpp
+++ b/bin_search.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 
 struct Searcher {
     int *t;

--- a/convex_hull_trick.hpp
+++ b/convex_hull_trick.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 struct Line {
     long long m, b;
 

--- a/convex_hull_trick_cartesian.hpp
+++ b/convex_hull_trick_cartesian.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 struct Line {
     long long m, b;
 

--- a/dfa.hpp
+++ b/dfa.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 struct Automaton {
     using moves_t = vector <pair <int, int> >;
     vector <moves_t> go;

--- a/dinic.hpp
+++ b/dinic.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 struct Dinic {
 
 #define i64 long long

--- a/dominator_tree.hpp
+++ b/dominator_tree.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 namespace DOM {
     const int N=1e6+5,M=1e6+5;
     int cnt,dfn_cnt,last[N],lastpre[N],lastsdom[N],dfn[N],id[N],par[N],fa[N],best[N],sdom[N],idom[N],size[N];

--- a/euler_tour_link_cut.hpp
+++ b/euler_tour_link_cut.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 struct euler_tour_tree {
     struct node {
         int x, s;

--- a/factor.hpp
+++ b/factor.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 ll mulMOD(ll a, ll b, const ll MOD) {
     return __int128(a) * b % MOD;
 }

--- a/fast_divider.hpp
+++ b/fast_divider.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 struct divider_32 {
     uint32_t value;
     uint32_t magic;

--- a/fast_input.hpp
+++ b/fast_input.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 namespace Scanner {
     const static int BUF_SIZE = 65536;
     static char input[BUF_SIZE];

--- a/fft_arbitrary_mod.hpp
+++ b/fft_arbitrary_mod.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 int MOD = 1000000007;
 
 #define sz(x) ((x).size())

--- a/hash_suffixes.hpp
+++ b/hash_suffixes.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 
 string t;
 vector <long long> hashes;

--- a/heavy_light_decomposition.hpp
+++ b/heavy_light_decomposition.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 struct Hld {
     vector <int> path;
     vector <vector <int> > g;

--- a/heavy_light_non_recursive.hpp
+++ b/heavy_light_non_recursive.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 struct Hld {
     vector<int> path;
     vector<vector<int> > g;

--- a/hll.hpp
+++ b/hll.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 template <int np_ = 14>
 struct hll {
     uint8_t data[1 << np_];

--- a/implicit_treap.hpp
+++ b/implicit_treap.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 mt19937 generator;
 
 template <class K, class V>

--- a/karatsuba.hpp
+++ b/karatsuba.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 
 template <class T>
 struct karatsuba {

--- a/linear_inequality_count.hpp
+++ b/linear_inequality_count.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 template <typename c_type, typename o_type>
 o_type get_count(c_type A, c_type B, o_type C, o_type X);
 

--- a/log_num.hpp
+++ b/log_num.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 template <typename T>
 struct Num {
     T lv;

--- a/matrix_multiplication.hpp
+++ b/matrix_multiplication.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 const long long mod = 1000000007;
 
 template <int N, int M>

--- a/miller_rabin.hpp
+++ b/miller_rabin.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 struct miller_rabin {
     static ll mulmod(ll a, ll b, ll mod) {
         ll x = 0, y = a % mod;

--- a/ntt.hpp
+++ b/ntt.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 const ll mod = 998244353;
 ll root = 3;
 ll root_1 = 0;

--- a/palindromic_tree.hpp
+++ b/palindromic_tree.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 struct PalTree {
     const static int maxn = 111111;
 

--- a/persistent_cartesian.hpp
+++ b/persistent_cartesian.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 struct hdata {
     ll h1;
     ll h2;

--- a/poly_inverse.hpp
+++ b/poly_inverse.hpp
@@ -1,1 +1,3 @@
+#include <bits/stdc++.h>
+
 

--- a/smart_pointer.hpp
+++ b/smart_pointer.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 template <class item>
 struct pitem {
     item *data;

--- a/xor_convolution.hpp
+++ b/xor_convolution.hpp
@@ -1,3 +1,5 @@
+#include <bits/stdc++.h>
+
 template <class T>
 void walshTransform(T * data, int n) {
     for (int len = 2; len <= n; len <<= 1) {


### PR DESCRIPTION
## Summary
- add `#include <bits/stdc++.h>` to headers missing includes

## Testing
- `g++ -std=gnu++17 tmp.cpp -c` for each patched header (some failures due to incomplete snippets)

------
https://chatgpt.com/codex/tasks/task_b_685fdbc09f6483279ce821b93c348dd2