### PR TITLE
Fix missing ll aliases in headers

### DIFF
--- a/add_min_segment_tree.hpp
+++ b/add_min_segment_tree.hpp
@@ -1,4 +1,5 @@
 #include <bits/stdc++.h>
+using ll = long long;
 
 struct Data {
     int val;

--- a/convex_hull_trick_cartesian.hpp
+++ b/convex_hull_trick_cartesian.hpp
@@ -1,5 +1,6 @@
 #include <bits/stdc++.h>
 using namespace std;
+using ll = long long;
 
 struct Line {
     long long m, b;

--- a/dominator_tree.hpp
+++ b/dominator_tree.hpp
@@ -1,5 +1,6 @@
 #include <bits/stdc++.h>
 using namespace std;
+using ll = long long;
 
 #define pb push_back
 #define all(x) (x).begin(), (x).end()

--- a/factor.hpp
+++ b/factor.hpp
@@ -1,5 +1,6 @@
 #include <bits/stdc++.h>
 using namespace std;
+using ll = long long;
 
 ll mulMOD(ll a, ll b, const ll MOD) {
     return __int128(a) * b % MOD;

--- a/linear_inequality_count.hpp
+++ b/linear_inequality_count.hpp
@@ -1,4 +1,5 @@
 #include <bits/stdc++.h>
+using ll = long long;
 
 template <typename c_type, typename o_type>
 o_type get_count(c_type A, c_type B, o_type C, o_type X);

--- a/miller_rabin.hpp
+++ b/miller_rabin.hpp
@@ -1,4 +1,5 @@
 #include <bits/stdc++.h>
+using ll = long long;
 
 struct miller_rabin {
     static ll mulmod(ll a, ll b, ll mod) {

--- a/ntt.hpp
+++ b/ntt.hpp
@@ -1,5 +1,6 @@
 #include <bits/stdc++.h>
 using namespace std;
+using ll = long long;
 
 const ll mod = 998244353;
 ll root = 3;


### PR DESCRIPTION
## Summary
- add `using ll = long long;` in several headers that use `ll`

## Testing
- `./test/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_b_685fe830750083279e305e93ff24453e