### PR TITLE
Fix build() argument type in log_num.hpp

### DIFF
--- a/log_num.hpp
+++ b/log_num.hpp
@@ -14,7 +14,7 @@ struct Num {
         }
     }
 
-    static Num build(ld value) {
+    static Num build(T value) {
         Num res;
         res.lv = value;
         return res;


### PR DESCRIPTION
## Summary
- fix the `log_num.hpp` `build()` function to use template type `T`
- run existing tests

## Testing
- `bash test/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_b_685fea7697188327b36808b49a45af61