### PR TITLE
Fix assert parenthesis in convex_hull_trick

### DIFF
--- a/convex_hull_trick.hpp
+++ b/convex_hull_trick.hpp
@@ -18,7 +18,8 @@ struct Hull {
     vector <Line> lines;
 
     void add(const Line &line) {
-        if (!lines.empty()) assert(line.m > lines.back().m || (line.m == lines.back().m && line.b > /* < for minima */ lines.back().b);
+        if (!lines.empty()) assert(line.m > lines.back().m ||
+               (line.m == lines.back().m && line.b > /* < for minima */ lines.back().b));
         while (lines.size() >= 2 && comp(lines[lines.size() - 2], lines[lines.size() - 1], line) >= 0 /* <= 0 for minima */) {
             lines.pop_back();
         }


### PR DESCRIPTION
## Summary
- close missing parenthesis in `Hull::add`

## Testing
- `bash test/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_b_685feae05a98832784f4ffd296e7e2f9