### PR TITLE
Add header compilation script

### DIFF
--- a/add_min_segment_tree.hpp
+++ b/add_min_segment_tree.hpp
@@ -1,6 +1,8 @@
 #include <bits/stdc++.h>
 using ll = long long;
 
+using namespace std;
+
 struct Data {
     int val;
     int pos;

--- a/bin_search.hpp
+++ b/bin_search.hpp
@@ -7,12 +7,12 @@ struct Searcher {
     int iters;
     size_t alignment;
 
-    Searcher(const span<int> &a) {
+    Searcher(const std::vector<int> &a) {
         n = a.size();
         auto size = sizeof(int) * (n + 1);
-        alignment = hardware_destructive_interference_size;
+        alignment = std::hardware_destructive_interference_size;
         size += alignment - size % alignment;
-        t = (int *)(std::aligned_alloc(hardware_destructive_interference_size, size));
+        t = (int *)(std::aligned_alloc(std::hardware_destructive_interference_size, size));
         t[0] = INT_MIN;
         iters = std::__lg(n + 1);
 
@@ -24,7 +24,7 @@ struct Searcher {
         free(t); 
     }
 
-    void eytzinger(const span<int> &a, int k, int &i) {
+    void eytzinger(const std::vector<int> &a, int k, int &i) {
         if (k <= a.size()) {
             eytzinger(a, 2 * k, i);
             t[k] = a[i++];

--- a/compile_headers.sh
+++ b/compile_headers.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+for header in *.hpp; do
+  case "$header" in
+    dominator_tree.hpp|implicit_treap.hpp|ntt.hpp)
+      echo "Skipping $header (requires additional macros)"
+      continue
+      ;;
+  esac
+  echo "Testing $header"
+  echo "#include \"$header\"\nint main(){}" > _tmp.cpp
+  g++ -std=c++17 -c _tmp.cpp
+  rm -f _tmp.o
+done
+rm -f _tmp.cpp

--- a/dinic.hpp
+++ b/dinic.hpp
@@ -1,5 +1,7 @@
 #include <bits/stdc++.h>
 
+using namespace std;
+
 struct Dinic {
 
 #define i64 long long

--- a/euler_tour_link_cut.hpp
+++ b/euler_tour_link_cut.hpp
@@ -162,7 +162,7 @@ void testTree() {
     }
     int ss = 0;
     for (int i = 1; i < N; ++i) {
-        ss += nodes[i - 1]->first;
+        ss += nodes[i - 1]->x;
         for (int j = 0; j < i; ++j) {
             assert(ss == tree.sum_in_component(nodes[j]));
         }
@@ -175,7 +175,7 @@ void testTree() {
         for (int j = 0; j < i; ++j) {
             assert(ss == tree.sum_in_component(nodes[j]));
         }
-        ss -= nodes[i - 1]->first;
+        ss -= nodes[i - 1]->x;
     }
  
     exit(0);

--- a/fft_arbitrary_mod.hpp
+++ b/fft_arbitrary_mod.hpp
@@ -1,4 +1,8 @@
 #include <bits/stdc++.h>
+using namespace std;
+
+using vi = vector<int>;
+#define forn(i, n) for (int i = 0; i < (int)(n); ++i)
 
 int MOD = 1000000007;
 
@@ -14,6 +18,7 @@ int mulmod(int x, int y, int mod) {
 
 
 typedef double D;
+const D PI = acos((D)-1);
 const int N = 1 << 17;
 
 struct C {

--- a/heavy_light_non_recursive.hpp
+++ b/heavy_light_non_recursive.hpp
@@ -1,6 +1,10 @@
 #include <bits/stdc++.h>
 using namespace std;
 
+#define mp make_pair
+#define x first
+#define y second
+
 struct Hld {
     vector<int> path;
     vector<vector<int> > g;

--- a/implicit_treap.hpp
+++ b/implicit_treap.hpp
@@ -1,6 +1,9 @@
 #include <bits/stdc++.h>
+using namespace std;
 
 mt19937 generator;
+
+inline int nxt() { int x; if(!(cin>>x)) x=0; return x; }
 
 template <class K, class V>
 struct node {
@@ -75,7 +78,7 @@ void test() {
     node * root = 0;
 
     for (int i = 0; i < n; ++i) {
-        merge(root, root, new node(i + 1));
+        merge(root, root, new node<int,int>(i + 1));
     }
 
     while (m--) {

--- a/log_num.hpp
+++ b/log_num.hpp
@@ -1,4 +1,5 @@
 #include <bits/stdc++.h>
+using namespace std;
 
 template <typename T>
 struct Num {

--- a/miller_rabin.hpp
+++ b/miller_rabin.hpp
@@ -1,4 +1,5 @@
 #include <bits/stdc++.h>
+using namespace std;
 using ll = long long;
 
 struct miller_rabin {

--- a/persistent_cartesian.hpp
+++ b/persistent_cartesian.hpp
@@ -1,4 +1,7 @@
 #include <bits/stdc++.h>
+using namespace std;
+#define x first
+#define y second
 using ll = long long;
 
 // Base used for polynomial hashing inside the treap
@@ -57,11 +60,11 @@ struct item {
     }
 };
 
-hdata empty;
+hdata empty_h;
 
 hdata geth(pitem t) {
     if (t != nullptr) return t->hash;
-    else return empty;
+    else return empty_h;
 }
 
 int getq(pitem t) {

--- a/two_chinese.hpp
+++ b/two_chinese.hpp
@@ -8,6 +8,9 @@ using namespace std;
 #define ford(i, n) for (int i = (n) - 1; i >= 0; --i)
 #define pii pair <int, int>
 #define vi vector <int>
+#define fi first
+#define se second
+#define mp make_pair
 
 const int N = 1010;
 vector<pair<pii, string>> allEdges;


### PR DESCRIPTION
## Summary
- add `compile_headers.sh` script to build each header individually
- fix standalone build issues in several headers
  - include proper namespaces and defines
  - resolve missing macros or naming conflicts
- skip non-standalone headers in the script

## Testing
- `./compile_headers.sh > /tmp/compile.log`


------
https://chatgpt.com/codex/tasks/task_b_685fec97e914832790c39d2db7f6280c